### PR TITLE
Add display notifications option

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Guard::Karma
 
 Guard plugin for [Karma](http://karma-runner.github.io/0.12/index.html).
-Unfortunatelly I couldn't find a way to run specific test file, so it runs them all, but it's still useful for me.
+Unfortunately I couldn't find a way to run specific test file, so it runs them all, but it's still useful for me.
 
 ## Installation
 
@@ -37,6 +37,7 @@ Supported options:
 ./node_modules/karma/bin/karma start spec/karma.conf.coffee --single-run
 ```
 - `all_on_start` - when true, tests will be run on guard start
+- `notification` - when true, display notification before and after tests run
 
 
 ## Contributing

--- a/lib/guard/karma.rb
+++ b/lib/guard/karma.rb
@@ -2,6 +2,11 @@ require "guard/karma/version"
 
 module Guard
   class Karma < Guard::Plugin
+    RUNNING_TITLE = 'Karma running...'.freeze
+    FAILED_TITLE = 'Karma failed.'.freeze
+    SUCCESS_TITLE = 'Karma success.'.freeze
+    MESSAGE = 'See console for results.'
+
     # Initializes a Guard plugin.
     # Don't do any work here, especially as Guard plugins get initialized even if they are not in an active group!
     #
@@ -9,6 +14,7 @@ module Guard
     # @option options [Array<Guard::Watcher>] watchers the Guard plugin file watchers
     # @option options [Symbol] group the group this Guard plugin belongs to
     # @option options [Boolean] any_return allow any object to be returned from a watcher
+    # @option options [Boolean] notification display notifications when tests run
     #
     def initialize(options = {})
       super
@@ -83,7 +89,21 @@ module Guard
     private
 
     def run_cmd
-      system(options[:cmd])
+      Guard::Compat::UI.info(RUNNING_TITLE, reset: true)
+
+      if options[:notification]
+        Guard::Compat::UI.notify('', title: RUNNING_TITLE, image: :pending, priority: -1)
+      end
+
+      rval = system(options[:cmd])
+
+      if options[:notification]
+        if rval
+          Guard::Compat::UI.notify(MESSAGE, title: SUCCESS_TITLE, image: :success, priority: -1)
+        else
+          Guard::Compat::UI.notify(MESSAGE, title: FAILED_TITLE, image: :failed, priority: 2)
+        end
+      end
     end
   end
 end

--- a/lib/guard/karma/notifier.rb
+++ b/lib/guard/karma/notifier.rb
@@ -1,0 +1,71 @@
+module Guard
+  class Karma < Guard::Plugin
+    class Notifier
+      RUNNING_TITLE = 'Karma running...'.freeze
+      FAILURE_TITLE = 'Karma failure.'.freeze
+      SUCCESS_TITLE = 'Karma success.'.freeze
+
+      attr_accessor :options
+
+      def initialize(options = {})
+        @options = options
+      end
+
+      def notify_start
+        return unless options[:notification]
+
+        Guard::Compat::UI.notify('', title: RUNNING_TITLE, image: :pending, priority: -1)
+      end
+
+      def notify(summary)
+        return unless options[:notification]
+
+        run_count, total_count, failure_count = parse_summary(summary)
+
+        body = "Executed #{run_count} of #{total_count}"
+        if failure_count > 0
+          body += " with #{failure_count} failure(s)"
+        end
+
+        title = title(failure_count)
+        image = image(failure_count)
+        priority = priority(image)
+        Guard::Compat::UI.notify(body, title: title, image: image, priority: priority)
+      end
+
+      private
+
+      def parse_summary(summary)
+        summary.match(/Executed\ (\d+)\ of\ (\d+)\ \((\d+)\ FAILED\)/) do |match|
+          return [match[1].to_i, match[2].to_i, match[3].to_i]
+        end
+
+        summary.match(/Executed\ (\d+)\ of\ (\d+)\ SUCCESS/) do |match|
+          return [match[1].to_i, match[2].to_i, 0]
+        end
+
+        [0, 0, 0]
+      end
+
+      def image(failure_count)
+        if failure_count > 0
+          :failed
+        else
+          :success
+        end
+      end
+
+      def priority(image)
+        { failed: 2, success: -1 }[image]
+      end
+
+      def title(failure_count)
+        if failure_count > 0
+          FAILURE_TITLE
+        else
+          SUCCESS_TITLE
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
@lesniakania Thanks for building this plugin!

I've added a display notifications option.

Example output:

```
14:43:57 - INFO - Running Karma
~/workspace/test

> dev-and-test-package@0.0.0 test-headless /Users/michwatt/workspace/test
> karma start config/unit-headless.js --single-run

INFO [karma]: Karma v0.12.37 server started at http://localhost:8089/__test/
INFO [launcher]: Starting browser PhantomJS
INFO [PhantomJS 1.9.8 (Mac OS X 0.0.0)]: Connected on socket G-QrEKy_8LyoDExFaxvx with id 13487022
PhantomJS 1.9.8 (Mac OS X 0.0.0): Executed 1093 of 1093 SUCCESS (19.943 secs / 19.778 secs)
```

```
14:44:29 - INFO - Running Karma

npm ERR! Darwin 15.5.0
npm ERR! argv "node" "/usr/local/bin/npm" "run" "test-headless"
npm ERR! node v0.10.44
npm ERR! npm  v2.15.1
npm ERR! code ELIFECYCLE
npm ERR! dev-and-test-package@0.0.0 test-headless: `karma start config/unit-headless.js --single-run`
npm ERR! Exit status 1
npm ERR!
npm ERR! Failed at the dev-and-test-package@0.0.0 test-headless script 'karma start config/unit-headless.js --single-run'.
npm ERR! This is most likely a problem with the dev-and-test-package package,
npm ERR! not with npm itself.
npm ERR! Tell the author that this fails on your system:
npm ERR!     karma start config/unit-headless.js --single-run
npm ERR! You can get information on how to open an issue for this project with:
npm ERR!     npm bugs dev-and-test-package
npm ERR! Or if that isn't available, you can get their info via:
npm ERR!
npm ERR!     npm owner ls dev-and-test-package
npm ERR! There is likely additional logging output above.

npm ERR! Please include the following file with any support request:
npm ERR!     /Users/michwatt/test/npm-debug.log
~/workspace/test

> dev-and-test-package@0.0.0 test-headless /Users/michwatt/workspace/test
> karma start config/unit-headless.js --single-run

INFO [karma]: Karma v0.12.37 server started at http://localhost:8089/__test/
INFO [launcher]: Starting browser PhantomJS
INFO [PhantomJS 1.9.8 (Mac OS X 0.0.0)]: Connected on socket qQuAXTEMpalHCMATa5p2 with id 57568163
PhantomJS 1.9.8 (Mac OS X 0.0.0) ViolationsCtrl should create the controller FAILED
    Expected {  } to be null.
    Error: Expected {  } to be null.
        at /Users/michwatt/workspace/spec/violation-main.spec.js:28
PhantomJS 1.9.8 (Mac OS X 0.0.0): Executed 1093 of 1093 (1 FAILED) (19.638 secs / 19.394 secs)
```

Example notifications:
<img width="414" alt="banners_and_alerts_and_1___users_michwatt_workspace_tetrationanalytics_ui__make_" src="https://cloud.githubusercontent.com/assets/103135/16510787/02fb9d58-3efe-11e6-93c0-aa759e74de29.png">

<img width="414" alt="banners_and_alerts_and_1___users_michwatt_workspace_tetrationanalytics_ui__ruby_" src="https://cloud.githubusercontent.com/assets/103135/16535205/8408e9cc-3f9a-11e6-8d27-cc04e981b3a2.png">

<img width="414" alt="banners_and_alerts_and_1___users_michwatt_workspace_tetrationanalytics_ui__fsevent_watch_" src="https://cloud.githubusercontent.com/assets/103135/16535218/907488b0-3f9a-11e6-99ea-85fb5b70d7cb.png">
