### PR TITLE
Improve parsing of output with skipped results

### DIFF
--- a/lib/guard/karma/notifier.rb
+++ b/lib/guard/karma/notifier.rb
@@ -36,11 +36,15 @@ module Guard
       private
 
       def parse_summary(summary)
+        # Example:
+        # Executed x of y (n FAILED) (skipped z)
         summary.match(/Executed\ (\d+)\ of\ (\d+)\ \((\d+)\ FAILED\)/) do |match|
           return [match[1].to_i, match[2].to_i, match[3].to_i]
         end
 
-        summary.match(/Executed\ (\d+)\ of\ (\d+)\ SUCCESS/) do |match|
+        # Example:
+        # Executed x of y (skipped z) SUCCESS
+        summary.match(/Executed\ (\d+)\ of\ (\d+).*\ SUCCESS/) do |match|
           return [match[1].to_i, match[2].to_i, 0]
         end
 


### PR DESCRIPTION
@lesniakania 

After adding some skipped tests I found that success notifications were broken. This minor change to the regex restores functionality.